### PR TITLE
Fix container so it can be run in a local VSCode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,39 +1,44 @@
 {
-    "name": "Ossprey",
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "GitHub.copilot",
-                "GitHub.copilot-chat", // Required for agent mode
-                "GitHub.copilot-mcp", // Adds MCP server UI
-                "ms-python.python",
-                "ms-python.vscode-pylance",
-                "njpwerner.autodocstring",
-                "ms-python.flake8",
-                "ms-python.isort",
-                "ms-python.black-formatter",
-                "python-poetry.vscode-py-poetry",
-                "aaron-bond.better-comments",
-                "github.vscode-github-actions",
-                "AmazonWebServices.aws-toolkit-vscode",
-                "ms-azuretools.vscode-docker"
-            ],
-            "settings": {
-                /* kill VS Code’s own telemetry */
-                "telemetry.telemetryLevel": "off",
-                /* silence every AWS extension that honours the AWS Toolkit flag */
-                "aws.telemetry": false,
-                /* CodeWhisperer / Amazon Q (same engine) */
-                "codeWhispererTelemetry": false,
-                // delete any extra spaces at line-end
-                "files.trimTrailingWhitespace": true,
-                // delete indent that ends up on otherwise-empty lines
-                "editor.trimAutoWhitespace": true,
-                // format on save with Black (removes W29x, E30x, etc.)
-                "editor.formatOnSave": true,
-                "python.formatting.provider": "black"
-            }
-        }
-    },
-    "postStartCommand": "bash .devcontainer/startup.sh"
+	"name": "Ossprey",
+	"image": "mcr.microsoft.com/devcontainers/python:3.12",
+	"features": {
+		"ghcr.io/devcontainers-extra/features/poetry:2": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"GitHub.copilot",
+				"GitHub.copilot-chat", // Required for agent mode
+				"GitHub.copilot-mcp", // Adds MCP server UI
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"njpwerner.autodocstring",
+				"ms-python.flake8",
+				"ms-python.isort",
+				"ms-python.black-formatter",
+				"python-poetry.vscode-py-poetry",
+				"aaron-bond.better-comments",
+				"github.vscode-github-actions",
+				"AmazonWebServices.aws-toolkit-vscode",
+				"ms-azuretools.vscode-docker"
+			],
+			"settings": {
+				/* kill VS Code’s own telemetry */
+				"telemetry.telemetryLevel": "off",
+				/* silence every AWS extension that honours the AWS Toolkit flag */
+				"aws.telemetry": false,
+				/* CodeWhisperer / Amazon Q (same engine) */
+				"codeWhispererTelemetry": false,
+				// delete any extra spaces at line-end
+				"files.trimTrailingWhitespace": true,
+				// delete indent that ends up on otherwise-empty lines
+				"editor.trimAutoWhitespace": true,
+				// format on save with Black (removes W29x, E30x, etc.)
+				"editor.formatOnSave": true,
+				"python.formatting.provider": "black",
+				"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+			}
+		}
+	},
+	"postStartCommand": "bash .devcontainer/startup.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
 	"name": "Ossprey",
 	"image": "mcr.microsoft.com/devcontainers/python:3.12",
 	"features": {
-		"ghcr.io/devcontainers-extra/features/poetry:2": {}
+		"ghcr.io/devcontainers-extra/features/poetry:2": {},
+		"ghcr.io/devcontainers/features/node:1": {}
 	},
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/startup.sh
+++ b/.devcontainer/startup.sh
@@ -1,6 +1,5 @@
-#!/bin/bash 
+#!/bin/bash
 # Setup poetry
-pip install poetry==2.0.1
 poetry config virtualenvs.in-project true
 poetry install
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.defaultInterpreterPath": "/home/codespace/.python/current/bin/python3",
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
     "files.trimTrailingWhitespace": true,
     "editor.trimAutoWhitespace": true,
     "editor.formatOnSave": true


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes the VSCode devcontainer configuration to enable local development by specifying a base Python 3.12 image with Poetry and Node.js features, removing the manual Poetry installation step from the startup script, and updating the Python interpreter path to use the workspace virtual environment instead of a codespace-specific path.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.devcontainer/devcontainer.json` |
| 2 | `.devcontainer/startup.sh` |
| 3 | `.vscode/settings.json` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->