### PR TITLE
fix: Update python dependabot to not auto update test projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a Dependabot configuration file to enable automated weekly dependency updates for Python packages in the root directory, while avoiding automatic updates to test projects as indicated by the PR title.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/dependabot.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->