### PR TITLE
(fix) update pytest

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2760,4 +2760,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "60284b1909ac6117ca1adf970501b07819ab0198670c3000a7e2016512395ecb"
+content-hash = "87c9605535098474e46c766382605ef763fdb0f51ba42af91e5c0904094a9fe4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ packageurl-python = "^0.16.0"
 ossbom = "^1.0.12"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.3.3"
+pytest = ">=8.3.3,<10.0.0"
 pytest-cov = "^5.0.0"
 taskipy = "^1.14.1"
 twine = "^6.1.0"


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the `pytest` dependency version constraint in the development dependencies from `^8.3.3` to `>=8.3.3,<10.0.0`, allowing for a broader range of compatible pytest versions while preventing automatic upgrades to major version 10. The corresponding lock file hash has been updated to reflect this change.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `pyproject.toml` |
| 2 | `poetry.lock` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->