### PR TITLE
feat: Show usage in verbose, and handle skipped scans.

### DIFF
--- a/ossprey/exceptions.py
+++ b/ossprey/exceptions.py
@@ -30,6 +30,15 @@ class ScanTimeoutException(Exception):
     pass
 
 
+class ScanSkippedException(Exception):
+    """Raised when the API skips a scan (e.g. quota exhausted)."""
+
+    def __init__(self, message: str = "Scan skipped", reset_at: str | None = None):
+        super().__init__(message)
+        self.message = message
+        self.reset_at = reset_at
+
+
 class PoetryNotFoundError(Exception):
     """Raised when poetry command is not available."""
 

--- a/ossprey/github_actions_reporter.py
+++ b/ossprey/github_actions_reporter.py
@@ -17,6 +17,29 @@ def can_report_to_github() -> bool:
     return not shutil.which("git") is None
 
 
+def report_scan_skipped(message: str, reset_at: Optional[str] = None, post_to_github: bool = False) -> None:
+    """Print a skip notice and optionally post it to the pull request summary."""
+    full_message = f"Ossprey scan skipped: {message}"
+    if reset_at:
+        full_message += f" Quota resets at {reset_at}."
+
+    print(full_message)
+    append_to_github_output("scan_skipped", "true")
+
+    if not post_to_github:
+        return
+
+    if not can_report_to_github():
+        logger.error("Git is not available, cannot post to GitHub")
+        return
+
+    details = create_github_details()
+    if details is None or not details.is_pull_request:
+        return
+
+    post_comment_to_github_summary(details.token, details.repo, details.pull_number, full_message)
+
+
 def print_gh_action_errors(sbom: OSSBOM, package_path: str, post_to_github: bool = False) -> bool:
     """
     Print the errors in a format that can be consumed by GitHub Actions

--- a/ossprey/main.py
+++ b/ossprey/main.py
@@ -4,10 +4,12 @@ import logging
 import sys
 
 from ossprey.args import parse_arguments
-from ossprey.exceptions import MaliciousPackageException
-from ossprey.github_actions_reporter import print_gh_action_errors
+from ossprey.exceptions import MaliciousPackageException, ScanSkippedException
+from ossprey.github_actions_reporter import print_gh_action_errors, report_scan_skipped
 from ossprey.log import init_logging
+from ossprey.ossprey import Ossprey
 from ossprey.scan import scan
+from ossprey.utils import format_quota_usage
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +45,18 @@ def main() -> None:
             # Process the result
             ret = print_gh_action_errors(sbom, args.package, args.github_comments)
 
+            if args.verbose and args.api_key:
+                quota = Ossprey(args.url, args.api_key).get_usage()
+                if quota:
+                    logger.info(format_quota_usage(quota))
+
             if not ret:
                 raise MaliciousPackageException("Error Malicious Package Found")
 
+        sys.exit(0)
+
+    except ScanSkippedException as e:
+        report_scan_skipped(e.message, e.reset_at, args.github_comments)
         sys.exit(0)
 
     except Exception as e:

--- a/ossprey/main.py
+++ b/ossprey/main.py
@@ -21,19 +21,24 @@ def main() -> None:
     init_logging(args.verbose)
 
     try:
-
         local_scan = None
+        client = None
+        
         if args.dry_run_safe:
             local_scan = "dry-run-safe"
         elif args.dry_run_malicious:
             local_scan = "dry-run-malicious"
+        else:
+            # Only create the client when doing a real API scan
+            client = Ossprey(args.url, args.api_key)
 
         sbom = scan(
             args.package,
             mode=args.mode,
             local_scan=local_scan,
+            client=client,
             url=args.url,
-            api_key=args.api_key,
+            api_key=args.api_key
         )
 
         if sbom:
@@ -45,8 +50,8 @@ def main() -> None:
             # Process the result
             ret = print_gh_action_errors(sbom, args.package, args.github_comments)
 
-            if args.verbose and args.api_key:
-                quota = Ossprey(args.url, args.api_key).get_usage()
+            if args.verbose and client:
+                quota = client.get_usage()
                 if quota:
                     logger.info(format_quota_usage(quota))
 

--- a/ossprey/models.py
+++ b/ossprey/models.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class ScanStatus(str, Enum):
+    SUCCEEDED = "SUCCEEDED"
+    SKIPPED = "SKIPPED"
+    FAILED = "FAILED"
+    RUNNING = "RUNNING"
+    QUEUED = "QUEUED"
+    PENDING = "PENDING"
+
+    @classmethod
+    def from_str(cls, value: Optional[str]) -> "ScanStatus":
+        if not value:
+            raise ValueError("scan status missing")
+        try:
+            return cls(value.strip().upper())
+        except ValueError as exc:
+            raise ValueError(f"unknown scan status: {value!r}") from exc
+
+
+@dataclass
+class QuotaUsage:
+    plan_name: Optional[str] = None
+    daily_limit: Optional[int] = None
+    monthly_limit: Optional[int] = None
+    daily_usage: Optional[int] = None
+    monthly_usage: Optional[int] = None
+    day_reset_at: Optional[str] = None
+    month_reset_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "QuotaUsage":
+        return cls(
+            plan_name=data.get("plan_name"),
+            daily_limit=data.get("daily_limit"),
+            monthly_limit=data.get("monthly_limit"),
+            daily_usage=data.get("daily_usage"),
+            monthly_usage=data.get("monthly_usage"),
+            day_reset_at=data.get("day_reset_at"),
+            month_reset_at=data.get("month_reset_at"),
+        )

--- a/ossprey/ossprey.py
+++ b/ossprey/ossprey.py
@@ -12,8 +12,10 @@ from ossprey.exceptions import (
     MissingAPIKeyException,
     MissingSBOMException,
     ScanFailedException,
+    ScanSkippedException,
     ScanTimeoutException,
 )
+from ossprey.models import QuotaUsage, ScanStatus
 
 logger = logging.getLogger(__name__)
 
@@ -86,14 +88,46 @@ class Ossprey:
                 raise ScanFailedException("Error returned when retrieving the results")
 
             ret = response.json()
-            if ret["status"] == "SUCCEEDED":
+            status = ScanStatus.from_str(ret.get("status"))
+
+            if status is ScanStatus.SUCCEEDED:
                 if "output" in ret:
                     return ret["output"]
-                else:
-                    raise MissingSBOMException("Error no SBOM returned")
+                raise MissingSBOMException("Error no SBOM returned")
+
+            if status is ScanStatus.SKIPPED:
+                raise ScanSkippedException(
+                    message=ret.get("message", "Scan skipped due to quota exhaustion"),
+                    reset_at=ret.get("reset_at"),
+                )
+
+            if status is ScanStatus.FAILED:
+                raise ScanFailedException(ret.get("message", "Scan failed"))
+
+            # RUNNING / PENDING -> continue polling
 
         logger.error("Scan took too long to complete")
         raise ScanTimeoutException("Scan took too long to complete")
+
+    def get_usage(self) -> QuotaUsage | None:
+        url = self.api_url + "/dashboard/v1/usage"
+        headers = {"Content-Type": "application/json", "x-api-key": self.api_key}
+
+        try:
+            response = self.session.get(url, headers=headers)
+        except requests.RequestException as e:
+            logger.debug(f"Usage request failed: {e}")
+            return None
+
+        if response.status_code != 200:
+            logger.debug(f"Usage endpoint returned {response.status_code}: {response.text}")
+            return None
+
+        try:
+            return QuotaUsage.from_dict(response.json())
+        except ValueError as e:
+            logger.debug(f"Failed to parse usage response: {e}")
+            return None
 
     @staticmethod
     def create_session() -> requests.Session:

--- a/ossprey/scan.py
+++ b/ossprey/scan.py
@@ -84,6 +84,7 @@ def scan(
     package_name: str,
     mode: str = "auto",
     local_scan: str | None = None,
+    client: Ossprey | None = None,
     url: str | None = None,
     api_key: str | None = None,
 ) -> OSSBOM:
@@ -122,7 +123,7 @@ def scan(
     logger.info(f"Scanning {len(sbom.get_components())} components")
 
     if not local_scan:
-        ossprey = Ossprey(url, api_key)
+        ossprey = client if client else Ossprey(url, api_key)
 
         # Compress to MINIBOM
         sbom = SBOMConverterFactory.to_minibom(sbom)

--- a/ossprey/test_github_actions_reporter.py
+++ b/ossprey/test_github_actions_reporter.py
@@ -13,6 +13,7 @@ from ossprey.github_actions_reporter import (
     can_report_to_github,
     post_comments_to_pull_request,
     post_comment_to_github_summary,
+    report_scan_skipped,
 )
 from ossbom.model.ossbom import OSSBOM
 from ossprey.github_actions_reporter import GitHubDetails
@@ -253,6 +254,52 @@ def test_create_github_details_pull_request_non_numeric(monkeypatch):
 
     assert details.is_pull_request is True
     assert details.commit_sha is None
+
+
+def test_report_scan_skipped_prints_and_appends_output():
+    """report_scan_skipped prints message and writes scan_skipped output flag."""
+    with patch("builtins.print") as mock_print, \
+         patch("ossprey.github_actions_reporter.append_to_github_output") as mock_append:
+        report_scan_skipped("Quota exhausted", "2026-04-29T00:00:00Z", post_to_github=False)
+
+    mock_print.assert_called_once()
+    printed = mock_print.call_args[0][0]
+    assert "Quota exhausted" in printed
+    assert "2026-04-29T00:00:00Z" in printed
+    mock_append.assert_called_once_with("scan_skipped", "true")
+
+
+def test_report_scan_skipped_posts_to_pull_request():
+    """When post_to_github is True and event is a PR, summary comment is posted."""
+    details_mock = MagicMock(is_pull_request=True, token="token", repo="repo", pull_number=1)
+
+    with patch("ossprey.github_actions_reporter.can_report_to_github", return_value=True), \
+         patch("ossprey.github_actions_reporter.create_github_details", return_value=details_mock), \
+         patch("ossprey.github_actions_reporter.append_to_github_output"), \
+         patch("ossprey.github_actions_reporter.post_comment_to_github_summary") as mock_post_summary, \
+         patch("builtins.print"):
+        report_scan_skipped("Quota exhausted", None, post_to_github=True)
+
+    mock_post_summary.assert_called_once()
+    args = mock_post_summary.call_args[0]
+    assert args[0] == "token"
+    assert args[1] == "repo"
+    assert args[2] == 1
+    assert "Quota exhausted" in args[3]
+
+
+def test_report_scan_skipped_no_post_when_not_pr():
+    """No summary comment when the workflow is not a pull request."""
+    details_mock = MagicMock(is_pull_request=False)
+
+    with patch("ossprey.github_actions_reporter.can_report_to_github", return_value=True), \
+         patch("ossprey.github_actions_reporter.create_github_details", return_value=details_mock), \
+         patch("ossprey.github_actions_reporter.append_to_github_output"), \
+         patch("ossprey.github_actions_reporter.post_comment_to_github_summary") as mock_post_summary, \
+         patch("builtins.print"):
+        report_scan_skipped("Quota exhausted", None, post_to_github=True)
+
+    mock_post_summary.assert_not_called()
 
 
 def test_create_github_details_pull_request_with_pr_number(monkeypatch):

--- a/ossprey/test_ossprey.py
+++ b/ossprey/test_ossprey.py
@@ -9,6 +9,7 @@ from ossprey.exceptions import (
     MissingAPIKeyException,
     MissingSBOMException,
     ScanFailedException,
+    ScanSkippedException,
     ScanTimeoutException,
 )
 
@@ -192,6 +193,70 @@ def test_wait_for_completion_timeout_raises():
     with patch.object(ossprey.session, "get", return_value=mock_response), \
          patch("time.sleep"):
         with pytest.raises(ScanTimeoutException):
+            ossprey.wait_for_completion("sbom-123", "scan-456")
+
+
+def test_wait_for_completion_skipped_raises():
+    """SKIPPED status raises ScanSkippedException with message and reset_at."""
+    ossprey = Ossprey("https://api.example.com", "test-api-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "status": "SKIPPED",
+        "message": "Quota exhausted",
+        "reset_at": "2026-04-29T00:00:00Z",
+    }
+
+    with patch.object(ossprey.session, "get", return_value=mock_response), \
+         patch("time.sleep"):
+        with pytest.raises(ScanSkippedException) as excinfo:
+            ossprey.wait_for_completion("sbom-123", "scan-456")
+
+    assert excinfo.value.message == "Quota exhausted"
+    assert excinfo.value.reset_at == "2026-04-29T00:00:00Z"
+
+
+def test_wait_for_completion_status_case_insensitive():
+    """Lowercase status string parses to the same enum value."""
+    ossprey = Ossprey("https://api.example.com", "test-api-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "succeeded", "output": {"components": []}}
+
+    with patch.object(ossprey.session, "get", return_value=mock_response), \
+         patch("time.sleep"):
+        result = ossprey.wait_for_completion("sbom-123", "scan-456")
+
+    assert result == {"components": []}
+
+
+def test_wait_for_completion_failed_status_raises():
+    """FAILED status raises ScanFailedException with the API message."""
+    ossprey = Ossprey("https://api.example.com", "test-api-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "FAILED", "message": "boom"}
+
+    with patch.object(ossprey.session, "get", return_value=mock_response), \
+         patch("time.sleep"):
+        with pytest.raises(ScanFailedException, match="boom"):
+            ossprey.wait_for_completion("sbom-123", "scan-456")
+
+
+def test_wait_for_completion_unknown_status_raises():
+    """Unknown status string raises ValueError (tightened parsing)."""
+    ossprey = Ossprey("https://api.example.com", "test-api-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "NONSENSE"}
+
+    with patch.object(ossprey.session, "get", return_value=mock_response), \
+         patch("time.sleep"):
+        with pytest.raises(ValueError, match="unknown scan status"):
             ossprey.wait_for_completion("sbom-123", "scan-456")
 
 

--- a/ossprey/utils.py
+++ b/ossprey/utils.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from ossprey.models import QuotaUsage
+
+
+def format_quota_usage(quota: QuotaUsage) -> str:
+    if not quota:
+        return ""
+
+    lines = ["", "--- Quota Usage ---"]
+    if quota.plan_name:
+        lines.append(f"Plan: {quota.plan_name}")
+
+    if quota.daily_limit is not None and quota.daily_usage is not None:
+        daily_pct = (quota.daily_usage / quota.daily_limit * 100) if quota.daily_limit > 0 else 0
+        lines.append(
+            f"Daily:   {quota.daily_usage}/{quota.daily_limit} ({daily_pct:.1f}%) - Resets {quota.day_reset_at}"
+        )
+
+    if quota.monthly_limit is not None and quota.monthly_usage is not None:
+        monthly_pct = (quota.monthly_usage / quota.monthly_limit * 100) if quota.monthly_limit > 0 else 0
+        lines.append(
+            f"Monthly: {quota.monthly_usage}/{quota.monthly_limit} ({monthly_pct:.1f}%) - Resets {quota.month_reset_at}"
+        )
+
+    return "\n".join(lines)


### PR DESCRIPTION
When the daily or monthly quota is exceeded, scans that are not cached packages will be skipped. This change allows the CLI to display skipped scanned. We also added verbose mode logging to display quota usage on successful scans.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances the CLI to gracefully handle scan quota exhaustion by introducing a `ScanSkippedException` that captures when the API skips scans due to daily or monthly quota limits. The implementation adds a new `ScanStatus` enum for safer status parsing, a `QuotaUsage` model to track usage metrics, and a `/dashboard/v1/usage` endpoint client to fetch quota information. In verbose mode, successful scans now display quota usage statistics with percentage calculations and reset timestamps. When a scan is skipped, the CLI reports the skip reason and quota reset time to both stdout and optionally to GitHub pull request summaries, then exits gracefully with status 0.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `ossprey/models.py` |
| 2 | `ossprey/exceptions.py` |
| 3 | `ossprey/utils.py` |
| 4 | `ossprey/ossprey.py` |
| 5 | `ossprey/github_actions_reporter.py` |
| 6 | `ossprey/main.py` |
| 7 | `ossprey/test_ossprey.py` |
| 8 | `ossprey/test_github_actions_reporter.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->