### PR TITLE
fix: replace calls to poetry install, with dry-run

### DIFF
--- a/ossprey/exceptions.py
+++ b/ossprey/exceptions.py
@@ -39,12 +39,6 @@ class ScanSkippedException(Exception):
         self.reset_at = reset_at
 
 
-class PoetryNotFoundError(Exception):
-    """Raised when poetry command is not available."""
-
-    pass
-
-
 class NotAPoetryProjectError(Exception):
     """Raised when the directory doesn't contain a valid poetry project."""
 

--- a/ossprey/modes.py
+++ b/ossprey/modes.py
@@ -26,7 +26,6 @@ def get_modes(directory: str) -> list[str]:
 
     poetry_files = [
         "poetry.lock",
-        # TODO: this should be seperate, pyproject.toml does not mean it's poetry
         "pyproject.toml"
     ]
     if any(poetry_file in files for poetry_file in poetry_files):

--- a/ossprey/modes.py
+++ b/ossprey/modes.py
@@ -26,6 +26,7 @@ def get_modes(directory: str) -> list[str]:
 
     poetry_files = [
         "poetry.lock",
+        # TODO: this should be seperate, pyproject.toml does not mean it's poetry
         "pyproject.toml"
     ]
     if any(poetry_file in files for poetry_file in poetry_files):

--- a/ossprey/sbom_python.py
+++ b/ossprey/sbom_python.py
@@ -3,9 +3,9 @@ import logging
 import subprocess
 import json
 import os
+import re
 import sys
 import shutil
-import tempfile
 from pathlib import Path
 import tomllib
 from packageurl import PackageURL
@@ -132,50 +132,101 @@ def update_sbom_from_poetry(ossbom: OSSBOM, package_dir: str) -> OSSBOM:
     return ossbom
 
 
-def update_sbom_from_pip_dry_run(ossbom: OSSBOM, package_dir: str) -> OSSBOM:
-    """Resolve full dependency tree for a Python project via `pip install --dry-run --report`.
+def get_uv_binary() -> str:
+    """Return path to the uv binary.
 
-    Does not actually install or build packages with C extensions. Uses PEP 658
-    metadata where available; falls back to metadata-only sdist preparation
-    otherwise. Works with any PEP 517 build backend (poetry-core, hatchling,
-    setuptools, flit) without requiring the corresponding CLI tool.
+    uv ships as a Python wheel (declared in this package's dependencies) so it
+    lands next to the active Python in the venv's bin/. Fall back to PATH lookup
+    so users with a system-wide install also work.
     """
-    with tempfile.TemporaryDirectory(prefix="pip-dryrun-") as target_dir:
-        cmd = [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--dry-run",
-            "--ignore-installed",
-            "--no-cache-dir",
-            "--quiet",
-            "--target",
-            target_dir,
-            "--report",
-            "-",
-            package_dir,
-        ]
-        result = subprocess.run(
-            cmd,
-            check=True,
-            capture_output=True,
-            text=True,
-            env=os.environ.copy(),
+    venv_bin = Path(sys.executable).parent / "uv"
+    if venv_bin.exists():
+        return str(venv_bin)
+    if shutil.which("uv"):
+        return "uv"
+    raise FileNotFoundError("uv binary not found")
+
+
+_UV_REQ_LINE = re.compile(r"^([A-Za-z0-9_.\-]+)==([^\s;]+)")
+
+
+def _read_pyproject_root_pkg(pyproject_path: str) -> tuple[str, str] | None:
+    """Return (name, version) for the root package declared in pyproject.toml.
+
+    uv pip compile excludes the source package itself, so we add it back from
+    the manifest. Returns None if no root metadata is declared (e.g. tooling-only
+    pyproject.toml without [project] or [tool.poetry]).
+    """
+    try:
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+    except Exception as e:
+        logger.debug(f"Could not parse pyproject.toml: {e}")
+        return None
+
+    project = data.get("project", {})
+    name = project.get("name")
+    version = project.get("version")
+
+    if not name:
+        tool_poetry = data.get("tool", {}).get("poetry", {})
+        name = tool_poetry.get("name")
+        version = version or tool_poetry.get("version")
+
+    if not name:
+        return None
+    return name.lower(), version or "0.0.0"
+
+
+def update_sbom_from_uv(ossbom: OSSBOM, package_dir: str) -> OSSBOM:
+    """Resolve full dependency tree for a Python project via `uv pip compile --universal`.
+
+    Universal resolution captures platform-marker-conditional deps (e.g.
+    Windows-only colorama) that pip's per-environment resolver excludes.
+    Reads pyproject.toml only — does not install, build, or execute project code.
+    Works for any PEP 517 build backend (poetry-core, hatchling, setuptools, flit).
+    """
+    pyproject_path = os.path.join(package_dir, "pyproject.toml")
+    if not os.path.exists(pyproject_path):
+        raise FileNotFoundError(f"pyproject.toml not found in {package_dir}")
+
+    cmd = [
+        get_uv_binary(),
+        "pip",
+        "compile",
+        "--universal",
+        "--no-progress",
+        "--output-file",
+        "-",
+        pyproject_path,
+    ]
+    result = subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+
+    components = []
+    root = _read_pyproject_root_pkg(pyproject_path)
+    if root:
+        name, version = root
+        components.append(
+            Component.create(name=name, version=version, source="uv", type="pypi")
         )
 
-    report = json.loads(result.stdout)
-    components = [
-        Component.create(
-            name=entry["metadata"]["name"],
-            version=entry["metadata"]["version"],
-            source="pip",
-            type="pypi",
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = _UV_REQ_LINE.match(line)
+        if not match:
+            continue
+        name, version = match.group(1), match.group(2)
+        components.append(
+            Component.create(name=name.lower(), version=version, source="uv", type="pypi")
         )
-        for entry in report.get("install", [])
-        if entry.get("metadata", {}).get("name")
-        and entry.get("metadata", {}).get("version")
-    ]
     ossbom.add_components(components)
     return ossbom
 

--- a/ossprey/sbom_python.py
+++ b/ossprey/sbom_python.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 import shutil
+import tempfile
 from pathlib import Path
 import tomllib
 from packageurl import PackageURL
@@ -128,6 +129,54 @@ def update_sbom_from_poetry(ossbom: OSSBOM, package_dir: str) -> OSSBOM:
         ]
     )
 
+    return ossbom
+
+
+def update_sbom_from_pip_dry_run(ossbom: OSSBOM, package_dir: str) -> OSSBOM:
+    """Resolve full dependency tree for a Python project via `pip install --dry-run --report`.
+
+    Does not actually install or build packages with C extensions. Uses PEP 658
+    metadata where available; falls back to metadata-only sdist preparation
+    otherwise. Works with any PEP 517 build backend (poetry-core, hatchling,
+    setuptools, flit) without requiring the corresponding CLI tool.
+    """
+    with tempfile.TemporaryDirectory(prefix="pip-dryrun-") as target_dir:
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "--ignore-installed",
+            "--no-cache-dir",
+            "--quiet",
+            "--target",
+            target_dir,
+            "--report",
+            "-",
+            package_dir,
+        ]
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=os.environ.copy(),
+        )
+
+    report = json.loads(result.stdout)
+    components = [
+        Component.create(
+            name=entry["metadata"]["name"],
+            version=entry["metadata"]["version"],
+            source="pip",
+            type="pypi",
+        )
+        for entry in report.get("install", [])
+        if entry.get("metadata", {}).get("name")
+        and entry.get("metadata", {}).get("version")
+    ]
+    ossbom.add_components(components)
     return ossbom
 
 

--- a/ossprey/sbom_python.py
+++ b/ossprey/sbom_python.py
@@ -150,34 +150,6 @@ def get_uv_binary() -> str:
 _UV_REQ_LINE = re.compile(r"^([A-Za-z0-9_.\-]+)==([^\s;]+)")
 
 
-def _read_pyproject_root_pkg(pyproject_path: str) -> tuple[str, str] | None:
-    """Return (name, version) for the root package declared in pyproject.toml.
-
-    uv pip compile excludes the source package itself, so we add it back from
-    the manifest. Returns None if no root metadata is declared (e.g. tooling-only
-    pyproject.toml without [project] or [tool.poetry]).
-    """
-    try:
-        with open(pyproject_path, "rb") as f:
-            data = tomllib.load(f)
-    except Exception as e:
-        logger.debug(f"Could not parse pyproject.toml: {e}")
-        return None
-
-    project = data.get("project", {})
-    name = project.get("name")
-    version = project.get("version")
-
-    if not name:
-        tool_poetry = data.get("tool", {}).get("poetry", {})
-        name = tool_poetry.get("name")
-        version = version or tool_poetry.get("version")
-
-    if not name:
-        return None
-    return name.lower(), version or "0.0.0"
-
-
 def update_sbom_from_uv(ossbom: OSSBOM, package_dir: str) -> OSSBOM:
     """Resolve full dependency tree for a Python project via `uv pip compile --universal`.
 
@@ -209,13 +181,6 @@ def update_sbom_from_uv(ossbom: OSSBOM, package_dir: str) -> OSSBOM:
     )
 
     components = []
-    root = _read_pyproject_root_pkg(pyproject_path)
-    if root:
-        name, version = root
-        components.append(
-            Component.create(name=name, version=version, source="uv", type="pypi")
-        )
-
     for line in result.stdout.splitlines():
         line = line.strip()
         if not line or line.startswith("#"):

--- a/ossprey/sbom_python.py
+++ b/ossprey/sbom_python.py
@@ -14,7 +14,7 @@ from ossbom.model.ossbom import OSSBOM
 from ossbom.model.component import Component
 
 from ossprey.virtualenv import VirtualEnv
-from ossprey.exceptions import PoetryNotFoundError, NotAPoetryProjectError
+from ossprey.exceptions import NotAPoetryProjectError
 
 logger = logging.getLogger(__name__)
 
@@ -110,66 +110,14 @@ def get_poetry_purls_from_lock(lockfile: str = "poetry.lock") -> list[PackageURL
     return purls
 
 
-def _is_poetry_project(package_dir: str) -> bool:
-    """Check if the directory contains a valid poetry project."""
-    pyproject_path = os.path.join(package_dir, "pyproject.toml")
-    if not os.path.exists(pyproject_path):
-        return False
-
-    try:
-        with open(pyproject_path, "rb") as f:
-            pyproject_data = tomllib.load(f)
-
-        # Check if poetry is the build backend
-        build_backend = pyproject_data.get("build-system", {}).get("build-backend", "")
-        if "poetry" in build_backend:
-            return True
-
-        # Also check for [tool.poetry] section which indicates a poetry project
-        if "tool" in pyproject_data and "poetry" in pyproject_data["tool"]:
-            return True
-
-        return False
-    except Exception as e:
-        logger.debug(f"Error reading pyproject.toml: {e}")
-        return False
-
-
 def update_sbom_from_poetry(ossbom: OSSBOM, package_dir: str) -> OSSBOM:
+    lock_path = os.path.join(package_dir, "poetry.lock")
+    if not os.path.exists(lock_path):
+        raise NotAPoetryProjectError(
+            f"Directory {package_dir} does not contain a poetry.lock file"
+        )
 
-    # Check if poetry is installed
-    if not shutil.which("poetry"):
-        raise PoetryNotFoundError("poetry command not found in PATH")
-
-    if not os.path.exists(os.path.join(package_dir, "poetry.lock")):
-        # Check if poetry is installed (only needed when generating poetry.lock)
-        if not shutil.which("poetry"):
-            raise PoetryNotFoundError("poetry command not found in PATH")
-        # Run poetry install to generate the poetry.lock file
-        # Note: poetry can handle both poetry-native projects and standard PEP 621 pyproject.toml
-        try:
-            subprocess.run(
-                ["poetry", "install"],
-                cwd=package_dir,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as e:
-            # If poetry install fails and this isn't a poetry project, raise a specific error
-            if not _is_poetry_project(package_dir):
-                raise NotAPoetryProjectError(
-                    f"Directory {package_dir} does not contain a valid poetry project "
-                    f"and poetry install failed"
-                )
-            logger.error(f"Error running poetry install: {e}")
-            logger.debug(f"stderr: {e.stderr}")
-            logger.debug(f"stdout: {e.stdout}")
-
-            raise e
-
-    # Get the packages from the poetry.lock file
-    purls = get_poetry_purls_from_lock(os.path.join(package_dir, "poetry.lock"))
+    purls = get_poetry_purls_from_lock(lock_path)
 
     ossbom.add_components(
         [

--- a/ossprey/scan.py
+++ b/ossprey/scan.py
@@ -15,7 +15,7 @@ from ossprey.modes import get_modes, get_all_modes
 from ossprey.sbom_python import (
     update_sbom_from_requirements,
     update_sbom_from_poetry,
-    update_sbom_from_pip_dry_run,
+    update_sbom_from_uv,
     update_sbom_from_virtualenv,
     NotAPoetryProjectError,
 )
@@ -40,16 +40,15 @@ def scan_python(modes: list[str], sbom: OSSBOM, package_name: str) -> OSSBOM:
             sbom = update_sbom_from_poetry(sbom, package_name)
         except NotAPoetryProjectError:
             logger.info(
-                "No poetry.lock found, resolving dependencies via pip --dry-run"
+                "No poetry.lock found, resolving dependencies via uv"
             )
             try:
-                sbom = update_sbom_from_pip_dry_run(sbom, package_name)
-            except CalledProcessError as e:
+                sbom = update_sbom_from_uv(sbom, package_name)
+            except (CalledProcessError, FileNotFoundError) as e:
                 logger.warning(
-                    "pip --dry-run resolution failed, falling back to pipenv"
+                    "uv resolution failed, falling back to pipenv"
                 )
-                logger.debug(f"stderr: {e.stderr}")
-                logger.debug(f"stdout: {e.stdout}")
+                logger.debug(f"error: {e}")
                 modes.append("pipenv")
 
     if "pipenv" in modes:

--- a/ossprey/scan.py
+++ b/ossprey/scan.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from subprocess import CalledProcessError
 
 from ossprey.environment import get_environment_details
 from ossprey.exceptions import (
@@ -17,7 +16,6 @@ from ossprey.sbom_python import (
     update_sbom_from_poetry,
     update_sbom_from_virtualenv,
     NotAPoetryProjectError,
-    PoetryNotFoundError,
 )
 from ossprey.sbom_javascript import update_sbom_from_npm, update_sbom_from_yarn
 from ossprey.sbom_filesystem import update_sbom_from_filesystem
@@ -39,21 +37,9 @@ def scan_python(modes: list[str], sbom: OSSBOM, package_name: str) -> OSSBOM:
         try:
             sbom = update_sbom_from_poetry(sbom, package_name)
         except NotAPoetryProjectError:
-            logger.warning(
-                "Not a valid poetry project, attempting pipenv scan instead"
+            logger.info(
+                "No poetry.lock found, attempting pipenv scan instead"
             )
-            modes.append("pipenv")
-        except PoetryNotFoundError:
-            logger.error("Poetry command not found, attempting pipenv scan instead")
-            modes.append("pipenv")
-        except CalledProcessError as e:
-            logger.error(
-                "Error running poetry install (dependency resolution or network issue), "
-                "attempting pipenv scan instead"
-            )
-            logger.debug(e.stderr)
-            logger.debug("--")
-            logger.debug(e.stdout)
             modes.append("pipenv")
 
     if "pipenv" in modes:

--- a/ossprey/scan.py
+++ b/ossprey/scan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from subprocess import CalledProcessError
 
 from ossprey.environment import get_environment_details
 from ossprey.exceptions import (
@@ -14,6 +15,7 @@ from ossprey.modes import get_modes, get_all_modes
 from ossprey.sbom_python import (
     update_sbom_from_requirements,
     update_sbom_from_poetry,
+    update_sbom_from_pip_dry_run,
     update_sbom_from_virtualenv,
     NotAPoetryProjectError,
 )
@@ -38,9 +40,17 @@ def scan_python(modes: list[str], sbom: OSSBOM, package_name: str) -> OSSBOM:
             sbom = update_sbom_from_poetry(sbom, package_name)
         except NotAPoetryProjectError:
             logger.info(
-                "No poetry.lock found, attempting pipenv scan instead"
+                "No poetry.lock found, resolving dependencies via pip --dry-run"
             )
-            modes.append("pipenv")
+            try:
+                sbom = update_sbom_from_pip_dry_run(sbom, package_name)
+            except CalledProcessError as e:
+                logger.warning(
+                    "pip --dry-run resolution failed, falling back to pipenv"
+                )
+                logger.debug(f"stderr: {e.stderr}")
+                logger.debug(f"stdout: {e.stdout}")
+                modes.append("pipenv")
 
     if "pipenv" in modes:
         sbom = update_sbom_from_virtualenv(sbom, package_name)

--- a/ossprey/test_sbom_python.py
+++ b/ossprey/test_sbom_python.py
@@ -183,7 +183,6 @@ def test_update_sbom_from_uv_parses_compile_output(tmp_path):
 
     components = {c.name: c.version for c in ossbom.get_components()}
     assert components == {
-        "rootpkg": "1.2.3",
         "colorama": "0.4.6",
         "numpy": "1.24.0",
         "requests": "2.31.0",

--- a/ossprey/test_sbom_python.py
+++ b/ossprey/test_sbom_python.py
@@ -3,7 +3,7 @@ import os
 import sys
 import subprocess
 from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 import pytest
 import tempfile
 
@@ -12,10 +12,8 @@ from ossprey.sbom_python import (
     create_sbom_from_requirements,
     get_cyclonedx_binary,
     get_poetry_purls_from_lock,
-    _is_poetry_project,
     update_sbom_from_poetry,
     update_sbom_from_virtualenv,
-    PoetryNotFoundError,
     NotAPoetryProjectError,
 )
 from ossprey.virtualenv import VirtualEnv
@@ -86,74 +84,11 @@ def test_raises_when_not_found(mock_which, mock_exists):
         get_cyclonedx_binary()
 
 
-@patch("os.path.exists", return_value=False)
-@patch("shutil.which", return_value=None)
-def test_poetry_not_found_error(mock_which, mock_exists):
-    """Test that PoetryNotFoundError is raised when poetry command is not available."""
+def test_not_a_poetry_project_error(tmp_path):
+    """Test that NotAPoetryProjectError is raised when poetry.lock is missing."""
     ossbom = OSSBOM()
-    with pytest.raises(PoetryNotFoundError, match="poetry command not found in PATH"):
-        update_sbom_from_poetry(ossbom, "/tmp/test_dir")
-
-
-@patch("subprocess.run")
-@patch("os.path.exists")
-@patch("shutil.which", return_value="/usr/bin/poetry")
-def test_not_a_poetry_project_error(mock_which, mock_exists, mock_run):
-    """Test that NotAPoetryProjectError is raised when pyproject.toml doesn't contain poetry configuration."""
-    # Mock os.path.exists to return False for poetry.lock, True for pyproject.toml
-    def exists_side_effect(path):
-        # Use basename to avoid false positives from paths containing these strings
-        basename = os.path.basename(path)
-        if basename == "poetry.lock":
-            return False
-        elif basename == "pyproject.toml":
-            return True
-        return False
-    
-    mock_exists.side_effect = exists_side_effect
-    
-    # Mock subprocess.run to raise CalledProcessError for "poetry install" command
-    mock_run.side_effect = subprocess.CalledProcessError(
-        returncode=1, 
-        cmd=["poetry", "install"],
-        output="",
-        stderr="Error: not a poetry project"
-    )
-    
-    # Mock pyproject.toml reading to return non-poetry project
-    mock_toml_data = b'[build-system]\nrequires = ["setuptools"]\n'
-    
-    with patch("builtins.open", mock_open(read_data=mock_toml_data)):
-        ossbom = OSSBOM()
-        with pytest.raises(NotAPoetryProjectError, match="does not contain a valid poetry project"):
-            update_sbom_from_poetry(ossbom, "/tmp/test_dir")
-
-
-@patch("ossprey.scan.update_sbom_from_virtualenv")
-@patch("ossprey.scan.update_sbom_from_poetry")
-def test_fallback_to_pipenv_on_poetry_not_found(mock_update_poetry, mock_update_venv):
-    """Test that scan_python falls back to pipenv when PoetryNotFoundError occurs."""
-    from ossprey.scan import scan_python
-    
-    # Make update_sbom_from_poetry raise PoetryNotFoundError
-    mock_update_poetry.side_effect = PoetryNotFoundError("poetry command not found in PATH")
-    
-    # Create a mock return value for virtualenv
-    mock_sbom = OSSBOM()
-    mock_update_venv.return_value = mock_sbom
-    
-    # Call scan_python with poetry mode
-    modes = ["poetry"]
-    result = scan_python(modes, OSSBOM(), "/tmp/test_dir")
-    
-    # Verify that poetry was attempted
-    mock_update_poetry.assert_called_once()
-    
-    # Verify that pipenv was called as fallback
-    mock_update_venv.assert_called_once()
-    
-    # Verify that pipenv was added to modes (scan_python modifies the list in place)
-    assert "pipenv" in modes
+    with pytest.raises(NotAPoetryProjectError, match="does not contain a poetry.lock"):
+        update_sbom_from_poetry(ossbom, str(tmp_path))
 
 
 @patch("ossprey.scan.update_sbom_from_virtualenv")
@@ -161,27 +96,19 @@ def test_fallback_to_pipenv_on_poetry_not_found(mock_update_poetry, mock_update_
 def test_fallback_to_pipenv_on_not_a_poetry_project(mock_update_poetry, mock_update_venv):
     """Test that scan_python falls back to pipenv when NotAPoetryProjectError occurs."""
     from ossprey.scan import scan_python
-    
-    # Make update_sbom_from_poetry raise NotAPoetryProjectError
+
     mock_update_poetry.side_effect = NotAPoetryProjectError(
-        "Directory /tmp/test_dir does not contain a valid poetry project"
+        "Directory /tmp/test_dir does not contain a poetry.lock file"
     )
-    
-    # Create a mock return value for virtualenv
+
     mock_sbom = OSSBOM()
     mock_update_venv.return_value = mock_sbom
-    
-    # Call scan_python with poetry mode
+
     modes = ["poetry"]
-    result = scan_python(modes, OSSBOM(), "/tmp/test_dir")
-    
-    # Verify that poetry was attempted
+    scan_python(modes, OSSBOM(), "/tmp/test_dir")
+
     mock_update_poetry.assert_called_once()
-    
-    # Verify that pipenv was called as fallback
     mock_update_venv.assert_called_once()
-    
-    # Verify that pipenv was added to modes (scan_python modifies the list in place)
     assert "pipenv" in modes
 
 
@@ -234,35 +161,6 @@ description = "Numerical Python"
         os.unlink(lock_path)
 
 
-def test_is_poetry_project_with_tool_poetry_section(tmp_path):
-    """Test that _is_poetry_project returns True for [tool.poetry] section."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_bytes(b'[tool.poetry]\nname = "my-project"\n')
-
-    assert _is_poetry_project(str(tmp_path)) is True
-
-
-def test_is_poetry_project_with_poetry_build_backend(tmp_path):
-    """Test that _is_poetry_project returns True for poetry-core build backend."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_bytes(b'[build-system]\nbuild-backend = "poetry.core.masonry.api"\n')
-
-    assert _is_poetry_project(str(tmp_path)) is True
-
-
-def test_is_poetry_project_false_for_setuptools(tmp_path):
-    """Test that _is_poetry_project returns False for non-poetry projects."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_bytes(b'[build-system]\nbuild-backend = "setuptools.build_meta"\n')
-
-    assert _is_poetry_project(str(tmp_path)) is False
-
-
-def test_is_poetry_project_no_pyproject(tmp_path):
-    """Test that _is_poetry_project returns False when pyproject.toml doesn't exist."""
-    assert _is_poetry_project(str(tmp_path)) is False
-
-
 def test_update_sbom_from_poetry_with_existing_lock():
     """Test that update_sbom_from_poetry reads from existing poetry.lock."""
     ossbom = OSSBOM()
@@ -272,26 +170,3 @@ def test_update_sbom_from_poetry_with_existing_lock():
     names = [c.name for c in result.get_components()]
     assert "requests" in names
     assert "numpy" in names
-
-
-def test_is_poetry_project_exception_reading_toml(tmp_path):
-    """Test that _is_poetry_project returns False when reading pyproject.toml raises an error."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_bytes(b'[tool.poetry]\nname = "test"\n')
-
-    with patch("builtins.open", side_effect=OSError("permission denied")):
-        assert _is_poetry_project(str(tmp_path)) is False
-
-
-def test_update_sbom_from_poetry_is_poetry_project_called_process_error(tmp_path):
-    """Test that CalledProcessError is re-raised for a valid poetry project."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_bytes(b'[tool.poetry]\nname = "test"\n')
-
-    with patch("shutil.which", return_value="/usr/bin/poetry"), \
-         patch("subprocess.run") as mock_run:
-        mock_run.side_effect = subprocess.CalledProcessError(
-            returncode=1, cmd=["poetry", "install"], stderr="dependency error"
-        )
-        with pytest.raises(subprocess.CalledProcessError):
-            update_sbom_from_poetry(ossbom=OSSBOM(), package_dir=str(tmp_path))

--- a/ossprey/test_sbom_python.py
+++ b/ossprey/test_sbom_python.py
@@ -13,7 +13,7 @@ from ossprey.sbom_python import (
     get_cyclonedx_binary,
     get_poetry_purls_from_lock,
     update_sbom_from_poetry,
-    update_sbom_from_pip_dry_run,
+    update_sbom_from_uv,
     update_sbom_from_virtualenv,
     NotAPoetryProjectError,
 )
@@ -92,43 +92,40 @@ def test_not_a_poetry_project_error(tmp_path):
         update_sbom_from_poetry(ossbom, str(tmp_path))
 
 
-@patch("ossprey.scan.update_sbom_from_pip_dry_run")
+@patch("ossprey.scan.update_sbom_from_uv")
 @patch("ossprey.scan.update_sbom_from_poetry")
-def test_fallback_to_pip_dry_run_on_not_a_poetry_project(
-    mock_update_poetry, mock_update_dry_run
-):
-    """Test that scan_python falls back to pip --dry-run when poetry.lock is missing."""
+def test_fallback_to_uv_on_not_a_poetry_project(mock_update_poetry, mock_update_uv):
+    """scan_python falls back to uv when poetry.lock is missing."""
     from ossprey.scan import scan_python
 
     mock_update_poetry.side_effect = NotAPoetryProjectError(
         "Directory /tmp/test_dir does not contain a poetry.lock file"
     )
 
-    mock_sbom = OSSBOM()
-    mock_update_dry_run.return_value = mock_sbom
+    mock_update_uv.return_value = OSSBOM()
 
     modes = ["poetry"]
     scan_python(modes, OSSBOM(), "/tmp/test_dir")
 
     mock_update_poetry.assert_called_once()
-    mock_update_dry_run.assert_called_once()
+    mock_update_uv.assert_called_once()
     assert "pipenv" not in modes
 
 
 @patch("ossprey.scan.update_sbom_from_virtualenv")
-@patch("ossprey.scan.update_sbom_from_pip_dry_run")
+@patch("ossprey.scan.update_sbom_from_uv")
 @patch("ossprey.scan.update_sbom_from_poetry")
-def test_fallback_to_pipenv_when_pip_dry_run_fails(
-    mock_update_poetry, mock_update_dry_run, mock_update_venv
+def test_fallback_to_pipenv_when_uv_fails(
+    mock_update_poetry, mock_update_uv, mock_update_venv
 ):
-    """If pip --dry-run also fails, scan_python falls back to pipenv."""
+    """If uv also fails, scan_python falls back to pipenv."""
     from ossprey.scan import scan_python
 
     mock_update_poetry.side_effect = NotAPoetryProjectError(
         "Directory /tmp/test_dir does not contain a poetry.lock file"
     )
-    mock_update_dry_run.side_effect = subprocess.CalledProcessError(
-        returncode=1, cmd=["pip", "install", "--dry-run"], stderr="resolver error"
+    mock_update_uv.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd=["uv", "pip", "compile"], stderr="resolver error"
     )
     mock_update_venv.return_value = OSSBOM()
 
@@ -136,41 +133,81 @@ def test_fallback_to_pipenv_when_pip_dry_run_fails(
     scan_python(modes, OSSBOM(), "/tmp/test_dir")
 
     mock_update_poetry.assert_called_once()
-    mock_update_dry_run.assert_called_once()
+    mock_update_uv.assert_called_once()
     mock_update_venv.assert_called_once()
     assert "pipenv" in modes
 
 
-def test_update_sbom_from_pip_dry_run_parses_report():
-    """update_sbom_from_pip_dry_run resolves and parses pip's JSON report."""
-    fake_report = {
-        "version": "1",
-        "install": [
-            {"metadata": {"name": "requests", "version": "2.31.0"}},
-            {"metadata": {"name": "numpy", "version": "1.24.0"}},
-            {"metadata": {"name": "", "version": "0"}},  # filtered out
-        ],
-    }
-    completed = subprocess.CompletedProcess(
-        args=[], returncode=0, stdout=__import__("json").dumps(fake_report), stderr=""
+@patch("ossprey.scan.update_sbom_from_virtualenv")
+@patch("ossprey.scan.update_sbom_from_uv")
+@patch("ossprey.scan.update_sbom_from_poetry")
+def test_fallback_to_pipenv_when_uv_missing(
+    mock_update_poetry, mock_update_uv, mock_update_venv
+):
+    """If uv binary is missing, scan_python falls back to pipenv."""
+    from ossprey.scan import scan_python
+
+    mock_update_poetry.side_effect = NotAPoetryProjectError(
+        "Directory /tmp/test_dir does not contain a poetry.lock file"
     )
-    with patch("subprocess.run", return_value=completed):
-        ossbom = update_sbom_from_pip_dry_run(OSSBOM(), "/tmp/anything")
+    mock_update_uv.side_effect = FileNotFoundError("uv binary not found")
+    mock_update_venv.return_value = OSSBOM()
 
-    names = sorted(c.name for c in ossbom.get_components())
-    assert names == ["numpy", "requests"]
+    modes = ["poetry"]
+    scan_python(modes, OSSBOM(), "/tmp/test_dir")
+
+    mock_update_poetry.assert_called_once()
+    mock_update_uv.assert_called_once()
+    mock_update_venv.assert_called_once()
+    assert "pipenv" in modes
 
 
-def test_update_sbom_from_pip_dry_run_raises_on_pip_failure():
-    """update_sbom_from_pip_dry_run propagates CalledProcessError from pip."""
-    with patch("subprocess.run") as mock_run:
+def test_update_sbom_from_uv_parses_compile_output(tmp_path):
+    """update_sbom_from_uv parses uv pip compile output and includes the root pkg."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_bytes(b'[project]\nname = "rootpkg"\nversion = "1.2.3"\n')
+
+    fake_stdout = (
+        "# uv compile output\n"
+        "colorama==0.4.6 ; sys_platform == 'win32'\n"
+        "    # via click\n"
+        "requests==2.31.0\n"
+        "numpy==1.24.0\n"
+    )
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fake_stdout, stderr=""
+    )
+    with patch("subprocess.run", return_value=completed), \
+         patch("ossprey.sbom_python.get_uv_binary", return_value="/fake/uv"):
+        ossbom = update_sbom_from_uv(OSSBOM(), str(tmp_path))
+
+    components = {c.name: c.version for c in ossbom.get_components()}
+    assert components == {
+        "rootpkg": "1.2.3",
+        "colorama": "0.4.6",
+        "numpy": "1.24.0",
+        "requests": "2.31.0",
+    }
+
+
+def test_update_sbom_from_uv_raises_on_failure(tmp_path):
+    """update_sbom_from_uv propagates CalledProcessError from uv."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_bytes(b'[project]\nname = "x"\nversion = "0"\n')
+
+    with patch("subprocess.run") as mock_run, \
+         patch("ossprey.sbom_python.get_uv_binary", return_value="/fake/uv"):
         mock_run.side_effect = subprocess.CalledProcessError(
-            returncode=1,
-            cmd=["pip", "install", "--dry-run"],
-            stderr="resolution-impossible",
+            returncode=1, cmd=["uv", "pip", "compile"], stderr="resolution-impossible"
         )
         with pytest.raises(subprocess.CalledProcessError):
-            update_sbom_from_pip_dry_run(OSSBOM(), "/tmp/anything")
+            update_sbom_from_uv(OSSBOM(), str(tmp_path))
+
+
+def test_update_sbom_from_uv_missing_pyproject(tmp_path):
+    """update_sbom_from_uv raises FileNotFoundError when pyproject.toml is absent."""
+    with pytest.raises(FileNotFoundError, match="pyproject.toml not found"):
+        update_sbom_from_uv(OSSBOM(), str(tmp_path))
 
 
 def test_create_sbom_from_requirements_called_process_error():

--- a/ossprey/test_sbom_python.py
+++ b/ossprey/test_sbom_python.py
@@ -258,12 +258,12 @@ description = "Numerical Python"
         os.unlink(lock_path)
 
 
-def test_update_sbom_from_poetry_with_existing_lock():
-    """Test that update_sbom_from_poetry reads from existing poetry.lock."""
-    ossbom = OSSBOM()
-    result = update_sbom_from_poetry(ossbom, "test/test_packages/poetry_simple_math")
+def test_update_sbom_from_poetry_raises_when_no_lock():
+    """update_sbom_from_poetry raises NotAPoetryProjectError when no poetry.lock present.
 
-    assert isinstance(result, OSSBOM)
-    names = [c.name for c in result.get_components()]
-    assert "requests" in names
-    assert "numpy" in names
+    No side effects: does not run `poetry install` to generate a lock. Caller (scan_python)
+    catches this and falls back to uv-based pyproject resolution.
+    """
+    ossbom = OSSBOM()
+    with pytest.raises(NotAPoetryProjectError, match="does not contain a poetry.lock"):
+        update_sbom_from_poetry(ossbom, "test/test_packages/poetry_simple_math")

--- a/ossprey/test_sbom_python.py
+++ b/ossprey/test_sbom_python.py
@@ -13,6 +13,7 @@ from ossprey.sbom_python import (
     get_cyclonedx_binary,
     get_poetry_purls_from_lock,
     update_sbom_from_poetry,
+    update_sbom_from_pip_dry_run,
     update_sbom_from_virtualenv,
     NotAPoetryProjectError,
 )
@@ -91,10 +92,12 @@ def test_not_a_poetry_project_error(tmp_path):
         update_sbom_from_poetry(ossbom, str(tmp_path))
 
 
-@patch("ossprey.scan.update_sbom_from_virtualenv")
+@patch("ossprey.scan.update_sbom_from_pip_dry_run")
 @patch("ossprey.scan.update_sbom_from_poetry")
-def test_fallback_to_pipenv_on_not_a_poetry_project(mock_update_poetry, mock_update_venv):
-    """Test that scan_python falls back to pipenv when NotAPoetryProjectError occurs."""
+def test_fallback_to_pip_dry_run_on_not_a_poetry_project(
+    mock_update_poetry, mock_update_dry_run
+):
+    """Test that scan_python falls back to pip --dry-run when poetry.lock is missing."""
     from ossprey.scan import scan_python
 
     mock_update_poetry.side_effect = NotAPoetryProjectError(
@@ -102,14 +105,72 @@ def test_fallback_to_pipenv_on_not_a_poetry_project(mock_update_poetry, mock_upd
     )
 
     mock_sbom = OSSBOM()
-    mock_update_venv.return_value = mock_sbom
+    mock_update_dry_run.return_value = mock_sbom
 
     modes = ["poetry"]
     scan_python(modes, OSSBOM(), "/tmp/test_dir")
 
     mock_update_poetry.assert_called_once()
+    mock_update_dry_run.assert_called_once()
+    assert "pipenv" not in modes
+
+
+@patch("ossprey.scan.update_sbom_from_virtualenv")
+@patch("ossprey.scan.update_sbom_from_pip_dry_run")
+@patch("ossprey.scan.update_sbom_from_poetry")
+def test_fallback_to_pipenv_when_pip_dry_run_fails(
+    mock_update_poetry, mock_update_dry_run, mock_update_venv
+):
+    """If pip --dry-run also fails, scan_python falls back to pipenv."""
+    from ossprey.scan import scan_python
+
+    mock_update_poetry.side_effect = NotAPoetryProjectError(
+        "Directory /tmp/test_dir does not contain a poetry.lock file"
+    )
+    mock_update_dry_run.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd=["pip", "install", "--dry-run"], stderr="resolver error"
+    )
+    mock_update_venv.return_value = OSSBOM()
+
+    modes = ["poetry"]
+    scan_python(modes, OSSBOM(), "/tmp/test_dir")
+
+    mock_update_poetry.assert_called_once()
+    mock_update_dry_run.assert_called_once()
     mock_update_venv.assert_called_once()
     assert "pipenv" in modes
+
+
+def test_update_sbom_from_pip_dry_run_parses_report():
+    """update_sbom_from_pip_dry_run resolves and parses pip's JSON report."""
+    fake_report = {
+        "version": "1",
+        "install": [
+            {"metadata": {"name": "requests", "version": "2.31.0"}},
+            {"metadata": {"name": "numpy", "version": "1.24.0"}},
+            {"metadata": {"name": "", "version": "0"}},  # filtered out
+        ],
+    }
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=__import__("json").dumps(fake_report), stderr=""
+    )
+    with patch("subprocess.run", return_value=completed):
+        ossbom = update_sbom_from_pip_dry_run(OSSBOM(), "/tmp/anything")
+
+    names = sorted(c.name for c in ossbom.get_components())
+    assert names == ["numpy", "requests"]
+
+
+def test_update_sbom_from_pip_dry_run_raises_on_pip_failure():
+    """update_sbom_from_pip_dry_run propagates CalledProcessError from pip."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["pip", "install", "--dry-run"],
+            stderr="resolution-impossible",
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            update_sbom_from_pip_dry_run(OSSBOM(), "/tmp/anything")
 
 
 def test_create_sbom_from_requirements_called_process_error():

--- a/ossprey/test_scan.py
+++ b/ossprey/test_scan.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
-import subprocess
 from unittest.mock import patch, MagicMock
 
 from ossprey.scan import scan, scan_python
 from ossbom.model.ossbom import OSSBOM
 from ossprey.exceptions import NoPackageManagerException
-from ossprey.sbom_python import PoetryNotFoundError, NotAPoetryProjectError
 import pytest
 
 
@@ -120,25 +118,6 @@ def test_scan_dry_run_malicious_no_components(tmp_path) -> None:
     # fs mode on empty dir yields no components
     with pytest.raises(Exception, match="No components found"):
         scan(str(tmp_path), mode="fs", local_scan="dry-run-malicious")
-
-
-def test_scan_poetry_fallback_to_pipenv_on_called_process_error() -> None:
-    """Test that scan_python falls back to pipenv when CalledProcessError is raised."""
-    mock_sbom = OSSBOM()
-    with patch("ossprey.scan.update_sbom_from_poetry") as mock_poetry, \
-         patch("ossprey.scan.update_sbom_from_virtualenv", return_value=mock_sbom) as mock_venv:
-        mock_poetry.side_effect = subprocess.CalledProcessError(
-            returncode=1,
-            cmd=["poetry", "install"],
-            output="",
-            stderr="error",
-        )
-        modes = ["poetry"]
-        result = scan_python(modes, OSSBOM(), "/tmp/test_dir")
-
-    mock_poetry.assert_called_once()
-    mock_venv.assert_called_once()
-    assert "pipenv" in modes
 
 
 def test_scan_with_ossprey_api(monkeypatch) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1914,6 +1914,35 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
+name = "uv"
+version = "0.11.8"
+description = "An extremely fast Python package and project manager, written in Rust."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "uv-0.11.8-py3-none-linux_armv6l.whl", hash = "sha256:a53e704a780a9e78a50f5a880e99a690f84e6fb9e82610903ce26f47c271d74c"},
+    {file = "uv-0.11.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d414fc3795b6f56fb6b1fa359537930924fdfe857750a144d2aedf3077be3f1d"},
+    {file = "uv-0.11.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f0d402e182ab581e934c159cc9edf25ec6e08d32f29aa797980e949afefc87cd"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:877c9af3b3955a35ef739e5b2ba79c56dae5c4d50420a7ed908c0901e1c8c807"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:8278144df8d80a83f770c264a5e79ea50791316d2a0dda869e53b3c1174142a8"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3494ad32465f4e02259cfb104d24efe5bb8f7a782351f0354de9385415fb310"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4421e27e81f85bce3bdb75986c38b5f9bfab9cdccaf3d977cf124b3f0f0b989"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91943e77fc962752d4f64ad5739219858395981078051c740b28b52963b366aa"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:41fbba287efcc9bc9505a60549b3a223220da720eacd03be8c23d9daaafa44f4"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d97bb2920d6cddc07faa475013461294cc09b77ec8139278416c6e54b938d037"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fb6a755305eb1e081dfe6a8bc007dbae2d26fe75e551656ca7c9cd08fba21d26"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:841ecbb38532698f73b14b49dc5f0c5e756194c7fcf6e5c6b7ed3859200fe91b"},
+    {file = "uv-0.11.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b3ff2b20c1897105ebe7ed7f9b1b331c7171da029bc1e35970ce31dc086141c1"},
+    {file = "uv-0.11.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:ad381228b0170ef9646902c7e908d4a10a7ecc3da8139450506cf70c7e7f3e80"},
+    {file = "uv-0.11.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0172b5215544844cd3db0fa3c73a2eb74999b3f00cd2527dde578725076d7b65"},
+    {file = "uv-0.11.8-py3-none-win32.whl", hash = "sha256:e71c1dd23cbb480f3952c3a95b4fd00f96bd618e2a94583fc9388c500af3070d"},
+    {file = "uv-0.11.8-py3-none-win_amd64.whl", hash = "sha256:306c624c68d95dd7ea3647675323d72c1abc25f91c3e92ae4cd6f0f11b508726"},
+    {file = "uv-0.11.8-py3-none-win_arm64.whl", hash = "sha256:a9853456696d579f206135c9dda7227a6ed8311b8a9a0b9b2008c4ae81950efe"},
+    {file = "uv-0.11.8.tar.gz", hash = "sha256:bb2cf302b8503629aab6f0090a05551e6f8cfc2d687ca059cad7ec9e11214335"},
+]
+
+[[package]]
 name = "webcolors"
 version = "25.10.0"
 description = "A library for working with the color formats defined by HTML and CSS."
@@ -1928,4 +1957,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "2b855f55ae6d0639cde66e8e883550557a701f26895e2e17699915ff6996535c"
+content-hash = "c21a03a108feefdab93eb42840feffbf8fb67db43950344f4659fc5d886476a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requests = "^2.32.3"
 pygithub = "^2.4.0"
 packageurl-python = "^0.16.0"
 ossbom = "^1.0.13"
+uv = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.3.3,<10.0.0"

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -382,7 +382,8 @@ GITHUB_REPOS = [
     (
         "https://github.com/psf/requests",
         None,
-        "requests",
+        # requests itself won't appear — it's the root package; check a known dep
+        "urllib3",
     ),
 ]
 


### PR DESCRIPTION
Summary:
Previous commit removed poetry as it pulled in about 70mb of deps (mostly build deps). This has an edge case where when a pyproject.toml exists, but no poetry lock, we falled back to poetry to get the deps. 

I tried switching to pip --dry-run, however it only resolves what would actually be installed on the machine, which means we have failure cases where some deps are platform dependent. 

uv provides the same dry run, dependency resolution, but ships as a 10mb .whl, without the need to pull in the build time dependencies. The binary should be surfaced in the same way as poetry was, but without as much bloat. 


  Main changed:
  - pyproject.toml — added uv = "^0.11.0" runtime dep
 - wires uv as poetry-no-lock fallback; pipenv as last resort on CalledProcessError | FileNotFoundError

  Behaviour:

  ```
  ┌─────────────────────┬────────────────────────────────────────────────────────────────┐
  │     Repo state      │                            Resolver                            │
  ├─────────────────────┼────────────────────────────────────────────────────────────────┤
  │ poetry.lock present │ tomllib parses lock (no CLI)                                   │
  ├─────────────────────┼────────────────────────────────────────────────────────────────┤
  │ pyproject.toml only │ uv pip compile --universal (universal markers, exact versions) │
  ├─────────────────────┼────────────────────────────────────────────────────────────────┤
  │ uv fails or missing │ pipenv (heavy, last resort)                                    │
  └─────────────────────┴────────────────────────────────────────────────────────────────┘
```
  uv ships as PyPI wheel — pip install ossprey pulls uv binary into venv bin automatically. No service-side Dockerfile change needed; lambda gets uv via pip install -r requirements.txt step that already runs.