### PR TITLE
fix: migrate the python release action out of cicd repo into here

### DIFF
--- a/.github/actions/python-release/action.yml
+++ b/.github/actions/python-release/action.yml
@@ -1,0 +1,82 @@
+name: Python Release
+description: Test, tag, build, and publish a Python package to PyPI or TestPyPI using OIDC trusted publishing
+inputs:
+  working-directory:
+    description: "Directory to run the release from"
+    required: true
+  tag:
+    description: "Tag to create and push after tests pass"
+    required: true
+  test:
+    description: "Release a test version to TestPyPI"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+      - name: Validate tag format
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format. Use semantic versioning (e.g., v1.0.0)."
+            exit 1
+          fi
+        shell: bash
+
+      - name: Validate tag matches pyproject.toml version
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml)
+          EXPECTED_TAG="v$VERSION"
+          if [[ "$EXPECTED_TAG" != "${{ inputs.tag }}" ]]; then
+            echo "Tag does not match pyproject.toml version ($EXPECTED_TAG)"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          pip install poetry
+          poetry install
+        shell: bash
+
+      - name: Run unit tests
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          poetry run pytest
+        shell: bash
+
+      - name: Tag and push
+        if: ${{ inputs.test == 'false' }}
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ inputs.tag }}
+          git push origin ${{ inputs.tag }}
+        shell: bash
+
+      - name: Build distribution
+        working-directory: ${{ inputs.working-directory }}
+        run: poetry build
+        shell: bash
+
+      - name: Publish to PyPI
+        if: ${{ inputs.test == 'false' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          packages-dir: ${{ inputs.working-directory }}/dist
+
+      - name: Publish to TestPyPI
+        if: ${{ inputs.test == 'true' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          packages-dir: ${{ inputs.working-directory }}/dist
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,13 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Run python-release
-        uses: ossprey/cicd/python-release@main
+        uses: ./.github/actions/python-release
         with:
           working-directory: .
           tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
Moves the python-release action out of the `cicd` repo and into this repo because `cicd` is private and this repo is public, which was preventing the action from being accessible.