### PR TITLE
fix: set packages to write to prevent pre-publish action error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      packages: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Set `packages: write` to prevent pre-publish error