### PR TITLE
feat: use ossprey ref and bump to 1.1.8

### DIFF
--- a/.github/actions/python-release/action.yml
+++ b/.github/actions/python-release/action.yml
@@ -70,14 +70,14 @@ runs:
 
       - name: Publish to PyPI
         if: ${{ inputs.test == 'false' }}
-        uses: andyantrim/gh-action-pypi-publish@e6bb70fa3edad10e8fb7e05232d86dbc7d990714
+        uses: ossprey/gh-action-pypi-publish@c491490ffbff6039ce817e25d6efa3bc36e90618
         with:
           use-canonical-image: true
           packages-dir: ${{ inputs.working-directory }}/dist
 
       - name: Publish to TestPyPI
         if: ${{ inputs.test == 'true' }}
-        uses: andyantrim/gh-action-pypi-publish@e6bb70fa3edad10e8fb7e05232d86dbc7d990714
+        uses: ossprey/gh-action-pypi-publish@c491490ffbff6039ce817e25d6efa3bc36e90618
         with:
           use-canonical-image: true
           packages-dir: ${{ inputs.working-directory }}/dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ossprey"
-version = "1.1.7"
+version = "1.1.8"
 description = "Ossprey tooling to scan your software package, create an SBOM and then submit it to our service for malware scanning"
 authors = ["dreadn0ught"]
 license = "GPL-3.0"


### PR DESCRIPTION
Use ossprey ref for workflow and bump to `v1.1.8`